### PR TITLE
Fixed `'SIGKILL' was not declared in this scope` error on FreeBSD 9.1

### DIFF
--- a/src/subprocesstest.cc
+++ b/src/subprocesstest.cc
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/signal.h>
 #include <cstdio>
 
 int main() {


### PR DESCRIPTION
Compilation fails on FreeBSD 9.1 and 8.0, seems like sys/signal.h header is needed.

[root@gendo ~/rsbackup-0.4.1]# make
make  all-recursive
Making all in src
g++ -Wall -W -Werror -Wpointer-arith -Wwrite-strings -DHAVE_CONFIG_H -I. -I..    -isystem /usr/local/include  -g -O2 -MT subprocesstest.o -MD -MP -MF .deps/subprocesstest.Tpo -c -o subprocesstest.o subprocesstest.cc
subprocesstest.cc: In function 'int main()':
subprocesstest.cc:37: error: 'SIGKILL' was not declared in this scope
**\* [subprocesstest.o] Error code 1

Stop in /root/rsbackup-0.4.1/src.
**\* [all-recursive] Error code 1

Stop in /root/rsbackup-0.4.1.
**\* [all] Error code 1

Stop in /root/rsbackup-0.4.1.
