### PR TITLE
Forward-port patch from Reiner Herrmann to make build reproducible

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -84,7 +84,7 @@ binary-rsbackup: build
 	cd debian/rsbackup && \
 	  find -name DEBIAN -prune -o -type f -print \
 	    | sed 's/^\.\///' \
-			| xargs md5sum > DEBIAN/md5sums
+			| LC_ALL=C sort | xargs md5sum > DEBIAN/md5sums
 	dpkg-gencontrol -isp -prsbackup -Pdebian/rsbackup \
 		-Tdebian/substvars.rsbackup
 	chown -R root:root debian/rsbackup


### PR DESCRIPTION
This sets LOCALE for the changelog generation from html with lynx
--dump, and sorts the md5sums list.

The original of this was included in 3.x; this version does the equivalent for 4.x