### PR TITLE
Add a NEWS.Debian.gz file documenting rejection of old logs

### DIFF
--- a/debian/NEWS
+++ b/debian/NEWS
@@ -1,0 +1,10 @@
+rsbackup (3.1-2) unstable; urgency=low
+
+  Old logfiles from rsbackup versions older than 2.0 (e.g. 1.1-4 shipped
+  with jessie) are not supported by rsbackup versions 7.0 and greater.
+
+  You must use a version of rsbackup between versions 2.0 and 6.0 to
+  upgrade these old logfiles. This includes those versions of rsbackup
+  shipped with stretch and buster.
+
+ -- Matthew Vernon <matthew@debian.org>  Sun, 16 Feb 2020 14:31:39 +0000

--- a/debian/rules
+++ b/debian/rules
@@ -63,6 +63,7 @@ binary-rsbackup: build
 	cp tools/rsbackup.defaults debian/rsbackup/etc/rsbackup/defaults
 	cp tools/rsbackup.devices debian/rsbackup/etc/rsbackup/devices
 	cp debian/changelog debian/rsbackup/usr/share/doc/rsbackup/changelog.Debian
+	cp debian/NEWS debian/rsbackup/usr/share/doc/rsbackup/NEWS.Debian
 	cp debian/doc.rsbackup debian/rsbackup/usr/share/doc-base/rsbackup
 	cp README.md debian/rsbackup/usr/share/doc/rsbackup/.
 	lynx -dump -nolist doc/CHANGES.html > debian/rsbackup/usr/share/doc/rsbackup/changelog


### PR DESCRIPTION
NEWS.Debian should be shown to people upgrading from an older version
than the version number in the NEWS entry. It is envisaged that this
NEWS will ship in rsbackup 7.0.

jessie had 1.1-4 so users upgrading should be shown the message if
they upgrade to 7.0 directly.

stretch had 3.1-3+b1 so users upgrading from stretch or later should
not be shown this message.

Signed-off-by: Matthew Vernon <matthew@debian.org>