### PR TITLE
rsbackup-snapshot-hook: swap udevadm for dmsetup

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,8 @@ Please see [rsbackup in git](https://github.com/ewxrjk/rsbackup) for detailed ch
 ## Changes In rsbackup 10.0
 
 * Pass `--open-noatime` to rsync by default. Fixes [issue #101](https://github.com/ewxrjk/rsbackup/issues/101).
+* `rsbackup-snapshot-hook` now uses `dmsetup` rather than `udevadm` to query logical volumes, which should stop it spuriously rejecting some of them. [Fixes issue #72](https://github.com/ewxrjk/rsbackup/issues/72).
+* `rsbackup-snapshot-hook` should now cope with volume group names containing hyphens.
 * **Incompatible change**: `rsync-timeout`, the old name for `backup-job-timeout`, has been removed.
 
 ## Changes In rsbackup 9.0

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -19,8 +19,8 @@ rsbackup-mount.in rsbackup-snapshot-hook.in		\
 ${TESTS}
 CRONJOBS=rsbackup.daily rsbackup.hourly rsbackup.weekly rsbackup.monthly
 noinst_SCRIPTS=${CRONJOBS}
-TESTS=t-bashisms t-hook-ok t-hook-fsck-ok t-hook-fsck-fail t-hook-post t-hook-nosnap \
-	t-hook-dryrun
+TESTS=t-bashisms t-hook-ok t-hook-fsck-ok t-hook-fsck-fail \
+	t-hook-notlv t-hook-lvlayer t-hook-post t-hook-nosnap t-hook-dryrun
 
 rsbackup.cron: rsbackup.cron.in Makefile
 	rm -f $@.new

--- a/tools/rsbackup-snapshot-hook.in
+++ b/tools/rsbackup-snapshot-hook.in
@@ -108,19 +108,26 @@ if ${RSBACKUP_ACT:-false} && $remote test -e $snap; then
   fi
   # Assume the name returned by dmsetup corresponds to a thing in /dev/mapper
   dev=/dev/mapper/"${dmname}"
-  # Pull out components. (whitespace is not permitted in LV/VG names)
+  # Pull out components.
+  # (whitespace separators are good enough: not permitted in LV/VG names,
+  # and if an empty component is followed by a non-empty one, something's
+  # gone badly wrong)
   dmsplit=$($remote dmsetup splitname --noheadings --separator ' ' "${dmname}" LVM)
   read -r vg lv lvlayer <<EOF
 ${dmsplit}
 EOF
-  # XXX will df ever point us toward a device where the third component,
-  # $lvlayer, is nonempty? Ought we to trap that? Ignored for now.
-  # (Creating a snapshot creates such a device with lvlayer='cow', but
-  # that doesn't show up in df. See also lvconvert(8) and lvmraid(7) --
-  # search for 'layer' for some situations where these internal layers /
-  # "sub LVs" are used.)
   if [ -z "${vg}" ] || [ -z "${lv}" ]; then
-    echo >&2 "ERROR: failed to parse ${dmname} as LVM name"
+    echo >&2 "ERROR: failed to parse ${dmname} as LVM name (dmsetup splitname gave \"$dmsplit\")"
+    exit 1
+  elif [ ! -z "${lvlayer}" ]; then
+    # All three components nonempty means we've ended up with an LVM
+    # internal layer, which is probably a mistake, which we shouldn't
+    # compound by continuing.
+    # (An LVM internal layer / sub-LV almost certainly shouldn't have been
+    # mounted; LVM invents them when it needs to compose multiple devmapper
+    # functionalities, for instance when creating a snapshot, or in some
+    # RAID situations -- see e.g. lvconvert(8) and lvmraid(7).)
+    echo >&2 "ERROR: cowardly refusing to work with sub-LV (${dmname} has non-empty layer component \"$lvlayer\")"
     exit 1
   fi
   snaplv="${lv}.snap"

--- a/tools/rsbackup-snapshot-hook.in
+++ b/tools/rsbackup-snapshot-hook.in
@@ -98,23 +98,35 @@ esac
 if ${RSBACKUP_ACT:-false} && $remote test -e $snap; then
   # Identify the device name
   devname=$($remote df ${RSBACKUP_VOLUME_PATH}|awk '/^\// { print $1}')
-  # Canonicalize the device name
-  dev=""
-  for alias in $(x $remote udevadm info -rqsymlink -n "$devname"); do
-    case "$alias" in
-    /dev/mapper/* )
-      dev="${alias}"
-      break
-      ;;
-    esac
-  done
-  if [ "${dev}" =  "" ]; then
-    echo >&2 "ERROR: cannot parse device name $devname"
+  # Canonicalize the device name to something LVM commands will recognise
+  # (in case df gave us something like /dev/dm-0).
+  # (dmsetup will barf if $devname isn't an LV)
+  dmname=$($remote dmsetup info --noheadings -c -o name "${devname}")
+  if [ -z "${dmname}" ]; then
+    echo >&2 "ERROR: no info from dmsetup for device ${devname}"
     exit 1
   fi
-  lv=${dev#*-}
-  snaplv=${lv}.snap
-  snapdev=${dev%-*}-${snaplv}
+  # Assume the name returned by dmsetup corresponds to a thing in /dev/mapper
+  dev=/dev/mapper/"${dmname}"
+  # Pull out components. (whitespace is not permitted in LV/VG names)
+  dmsplit=$($remote dmsetup splitname --noheadings --separator ' ' "${dmname}" LVM)
+  read -r vg lv lvlayer <<EOF
+${dmsplit}
+EOF
+  # XXX will df ever point us toward a device where the third component,
+  # $lvlayer, is nonempty? Ought we to trap that? Ignored for now.
+  # (Creating a snapshot creates such a device with lvlayer='cow', but
+  # that doesn't show up in df. See also lvconvert(8) and lvmraid(7) --
+  # search for 'layer' for some situations where these internal layers /
+  # "sub LVs" are used.)
+  if [ -z "${vg}" ] || [ -z "${lv}" ]; then
+    echo >&2 "ERROR: failed to parse ${dmname} as LVM name"
+    exit 1
+  fi
+  snaplv="${lv}.snap"
+  # Predict the snapshot device path. (Use the LVM-created alias rather
+  # than /dev/mapper/ so we don't have to contend with hyphen-stuffing.)
+  snapdev="/dev/${vg}/${snaplv}"
   case ${RSBACKUP_HOOK} in
   pre-volume-hook )
    # Tidy up any leftovers

--- a/tools/t-hook-dryrun
+++ b/tools/t-hook-dryrun
@@ -33,7 +33,7 @@ fake_cmd --must-not-run mount
 fake_cmd --must-not-run umount
 fake_cmd --must-not-run lvremove
 fake_cmd --must-not-run ssh
-fake_cmd --must-not-run udevadm
+fake_cmd --must-not-run dmsetup
 
 RSBACKUP_VOLUME=rsb-volume \
     RSBACKUP_VOLUME_PATH=/path/to/volume \

--- a/tools/t-hook-dryrun
+++ b/tools/t-hook-dryrun
@@ -36,9 +36,11 @@ fake_cmd --must-not-run ssh
 fake_cmd --must-not-run udevadm
 
 RSBACKUP_VOLUME=rsb-volume \
-    RSBACKUP_VOLUME_path=/path/to/volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
     RSBACKUP_SSH_TARGET=localhost \
     RSBACKUP_HOOK=pre-volume-hook \
     RSBACKUP_ACT=false \
     fake_run --must-output-empty \
     ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-fsck-fail
+++ b/tools/t-hook-fsck-fail
@@ -32,9 +32,9 @@ fake_cmd --must-run lvremove \
 fake_cmd --must-run lvdisplay \
          "echo '  Current LE             8192'; echo '  LV Path                /dev/vg/lv'" \
          --must-args /dev/mapper/vg-lv
-fake_cmd lvcreate \
+fake_cmd --must-run lvcreate \
          --must-args --extents 1638 --name lv.snap --snapshot /dev/vg/lv
-fake_cmd fsck "exit 2" \
+fake_cmd --must-run fsck "exit 2" \
          --must-args -a /dev/mapper/vg-lv.snap
 fake_cmd --must-run udevadm "echo /dev/dm-0 /dev/mapper/vg-lv" \
          --must-args info -rqsymlink -n /dev/mapper/vg-lv
@@ -44,9 +44,11 @@ fake_cmd --must-not-run mount
 fake_cmd --must-not-run ssh
 
 RSBACKUP_VOLUME=rsb-volume \
-    RSBACKUP_VOLUME_path=/path/to/volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
     RSBACKUP_SSH_TARGET=localhost \
     RSBACKUP_HOOK=pre-volume-hook \
     RSBACKUP_ACT=true \
     fake_run --must-exit 2 --must-output-empty \
     ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-fsck-fail
+++ b/tools/t-hook-fsck-fail
@@ -28,16 +28,20 @@ fake_reset
 fake_cmd --must-run df "echo /dev/mapper/vg-lv" \
          --must-args /path/to/volume
 fake_cmd --must-run lvremove \
-         --must-args --force /dev/mapper/vg-lv.snap
+         --must-args --force /dev/vg/lv.snap
 fake_cmd --must-run lvdisplay \
          "echo '  Current LE             8192'; echo '  LV Path                /dev/vg/lv'" \
          --must-args /dev/mapper/vg-lv
 fake_cmd --must-run lvcreate \
          --must-args --extents 1638 --name lv.snap --snapshot /dev/vg/lv
 fake_cmd --must-run fsck "exit 2" \
-         --must-args -a /dev/mapper/vg-lv.snap
-fake_cmd --must-run udevadm "echo /dev/dm-0 /dev/mapper/vg-lv" \
-         --must-args info -rqsymlink -n /dev/mapper/vg-lv
+         --must-args -a /dev/vg/lv.snap
+fake_cmd --must-run _dmsetup_info "echo vg-lv" \
+         --must-args info --noheadings -c -o name /dev/mapper/vg-lv
+fake_cmd --must-run _dmsetup_splitname "echo \"vg lv \"" \
+         --must-args splitname --noheadings --separator ' ' vg-lv LVM
+# Hack to mock two dmsetup verbs 'dmsetup info' / 'dmsetup splitname':
+fake_cmd dmsetup '_dmsetup_$1 "$@"'
 
 fake_cmd --must-not-run umount
 fake_cmd --must-not-run mount

--- a/tools/t-hook-fsck-ok
+++ b/tools/t-hook-fsck-ok
@@ -33,11 +33,15 @@ fake_cmd --must-run lvdisplay \
 fake_cmd --must-run lvcreate \
          --must-args --extents 1638 --name lv.snap --snapshot /dev/vg/lv
 fake_cmd --must-run fsck "exit 1" \
-         --must-args -a /dev/mapper/vg-lv.snap
+         --must-args -a /dev/vg/lv.snap
 fake_cmd --must-run mount \
-         --must-args -o ro /dev/mapper/vg-lv.snap ${fake_work}/snaps/rsb-volume
-fake_cmd --must-run udevadm "echo /dev/dm-0 /dev/mapper/vg-lv /dev/junk" \
-         --must-args info -rqsymlink -n /dev/dm-0
+         --must-args -o ro /dev/vg/lv.snap ${fake_work}/snaps/rsb-volume
+fake_cmd --must-run _dmsetup_info "echo vg-lv" \
+         --must-args info --noheadings -c -o name /dev/dm-0
+fake_cmd --must-run _dmsetup_splitname "echo \"vg lv \"" \
+         --must-args splitname --noheadings --separator ' ' vg-lv LVM
+# Hack to mock two dmsetup verbs 'dmsetup info' / 'dmsetup splitname':
+fake_cmd dmsetup '_dmsetup_$1 "$@"'
 
 fake_cmd --must-not-run umount
 fake_cmd --must-not-run lvremove

--- a/tools/t-hook-fsck-ok
+++ b/tools/t-hook-fsck-ok
@@ -44,9 +44,11 @@ fake_cmd --must-not-run lvremove
 fake_cmd --must-not-run ssh
 
 RSBACKUP_VOLUME=rsb-volume \
-    RSBACKUP_VOLUME_path=/path/to/volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
     RSBACKUP_SSH_TARGET=localhost \
     RSBACKUP_HOOK=pre-volume-hook \
     RSBACKUP_ACT=true \
     fake_run --must-output "${fake_work}/snaps/rsb-volume" \
     ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-lvlayer
+++ b/tools/t-hook-lvlayer
@@ -1,0 +1,53 @@
+#! /usr/bin/env bash
+#
+# Copyright © 2014, 2015 Richard Kettlewell.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. ${srcdir:-.}/../scripts/fakeshell.sh
+
+fake_init
+mkdir ${fake_work}/snaps
+mkdir ${fake_work}/snaps/rsb-volume
+
+fake_reset
+
+fake_cmd --must-run df "echo /dev/mapper/vg-lv-internal" \
+         --must-args /path/to/volume
+fake_cmd --must-run _dmsetup_info "echo vg-lv-internal" \
+         --must-args info --noheadings -c -o name /dev/mapper/vg-lv-internal
+fake_cmd --must-run _dmsetup_splitname "echo \"vg lv internal\"" \
+         --must-args splitname --noheadings --separator ' ' vg-lv-internal LVM
+# Hack to mock two dmsetup verbs 'dmsetup info' / 'dmsetup splitname':
+fake_cmd dmsetup '_dmsetup_$1 "$@"'
+
+fake_cmd --must-not-run umount
+fake_cmd --must-not-run mount
+fake_cmd --must-not-run ssh
+fake_cmd --must-not-run lvremove
+fake_cmd --must-not-run lvdisplay 
+fake_cmd --must-not-run lvcreate
+fake_cmd --must-not-run fsck
+
+RSBACKUP_VOLUME=rsb-volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
+    RSBACKUP_SSH_TARGET=localhost \
+    RSBACKUP_HOOK=pre-volume-hook \
+    RSBACKUP_ACT=true \
+    fake_run --must-exit 1 --must-output-empty \
+    ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-nosnap
+++ b/tools/t-hook-nosnap
@@ -32,7 +32,7 @@ fake_cmd --must-not-run mount
 fake_cmd --must-not-run umount
 fake_cmd --must-not-run lvremove
 fake_cmd --must-not-run ssh
-fake_cmd --must-not-run udevadm
+fake_cmd --must-not-run dmsetup
 
 RSBACKUP_VOLUME=rsb-volume \
     RSBACKUP_VOLUME_PATH=/path/to/volume \

--- a/tools/t-hook-nosnap
+++ b/tools/t-hook-nosnap
@@ -35,9 +35,11 @@ fake_cmd --must-not-run ssh
 fake_cmd --must-not-run udevadm
 
 RSBACKUP_VOLUME=rsb-volume \
-    RSBACKUP_VOLUME_path=/path/to/volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
     RSBACKUP_SSH_TARGET=localhost \
     RSBACKUP_HOOK=pre-volume-hook \
     RSBACKUP_ACT=true \
     fake_run --must-output-empty \
     ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-notlv
+++ b/tools/t-hook-notlv
@@ -1,0 +1,52 @@
+#! /usr/bin/env bash
+#
+# Copyright © 2014, 2015 Richard Kettlewell.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. ${srcdir:-.}/../scripts/fakeshell.sh
+
+fake_init
+mkdir ${fake_work}/snaps
+mkdir ${fake_work}/snaps/rsb-volume
+
+fake_reset
+
+fake_cmd --must-run df "echo /dev/sda1" \
+         --must-args /path/to/volume
+fake_cmd --must-run _dmsetup_info "echo >&2 Device sda1 not found; exit 1" \
+         --must-args info --noheadings -c -o name /dev/sda1
+fake_cmd --must-not-run _dmsetup_splitname
+# Hack to mock two dmsetup verbs 'dmsetup info' / 'dmsetup splitname':
+fake_cmd dmsetup '_dmsetup_$1 "$@"'
+
+fake_cmd --must-not-run umount
+fake_cmd --must-not-run mount
+fake_cmd --must-not-run ssh
+fake_cmd --must-not-run lvremove
+fake_cmd --must-not-run lvdisplay 
+fake_cmd --must-not-run lvcreate
+fake_cmd --must-not-run fsck
+
+RSBACKUP_VOLUME=rsb-volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
+    RSBACKUP_SSH_TARGET=localhost \
+    RSBACKUP_HOOK=pre-volume-hook \
+    RSBACKUP_ACT=true \
+    fake_run --must-exit 1 --must-output-empty \
+    ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-ok
+++ b/tools/t-hook-ok
@@ -25,19 +25,23 @@ mkdir ${fake_work}/snaps/rsb-volume
 
 fake_reset
 
-fake_cmd --must-run df "echo /dev/mapper/vg-lv" \
+fake_cmd --must-run df "echo /dev/mapper/vg--with--hyphens-lv" \
          --must-args /path/to/volume
 fake_cmd --must-run lvdisplay \
-         "echo '  Current LE             8192'; echo '  LV Path                /dev/vg/lv'" \
-         --must-args /dev/mapper/vg-lv
+         "echo '  Current LE             8192'; echo '  LV Path                /dev/vg-with-hyphens/lv'" \
+         --must-args /dev/mapper/vg--with--hyphens-lv
 fake_cmd --must-run lvcreate \
-         --must-args --extents 1638 --name lv.snap --snapshot /dev/vg/lv
+         --must-args --extents 1638 --name lv.snap --snapshot /dev/vg-with-hyphens/lv
 fake_cmd --must-run fsck \
-         --must-args -a /dev/mapper/vg-lv.snap
+         --must-args -a /dev/vg-with-hyphens/lv.snap
 fake_cmd --must-run mount \
-         --must-args -o ro /dev/mapper/vg-lv.snap ${fake_work}/snaps/rsb-volume
-fake_cmd --must-run udevadm "echo /dev/dm-0 /dev/mapper/vg-lv" \
-         --must-args info -rqsymlink -n /dev/mapper/vg-lv
+         --must-args -o ro /dev/vg-with-hyphens/lv.snap ${fake_work}/snaps/rsb-volume
+fake_cmd --must-run _dmsetup_info "echo vg--with--hyphens-lv" \
+         --must-args info --noheadings -c -o name /dev/mapper/vg--with--hyphens-lv
+fake_cmd --must-run _dmsetup_splitname "echo \"vg-with-hyphens lv \"" \
+         --must-args splitname --noheadings --separator ' ' vg--with--hyphens-lv LVM
+# Hack to mock two dmsetup verbs 'dmsetup info' / 'dmsetup splitname':
+fake_cmd dmsetup '_dmsetup_$1 "$@"'
 
 fake_cmd --must-not-run umount
 fake_cmd --must-not-run lvremove

--- a/tools/t-hook-ok
+++ b/tools/t-hook-ok
@@ -44,9 +44,11 @@ fake_cmd --must-not-run lvremove
 fake_cmd --must-not-run ssh
 
 RSBACKUP_VOLUME=rsb-volume \
-    RSBACKUP_VOLUME_path=/path/to/volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
     RSBACKUP_SSH_TARGET=localhost \
     RSBACKUP_HOOK=pre-volume-hook \
     RSBACKUP_ACT=true \
     fake_run --must-output "${fake_work}/snaps/rsb-volume" \
     ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-post
+++ b/tools/t-hook-post
@@ -27,9 +27,6 @@ fake_reset
 
 fake_cmd --must-run df "echo /dev/mapper/vg-lv" \
          --must-args /path/to/volume
-fake_cmd --must-run lvdisplay \
-         "echo '  Current LE             8192'; echo '  LV Path                /dev/vg/lv'" \
-         --must-args /dev/mapper/vg-lv
 fake_cmd --must-run umount \
          --must-args ${fake_work}/snaps/rsb-volume
 fake_cmd --must-run lvremove \
@@ -43,9 +40,11 @@ fake_cmd --must-not-run mount
 fake_cmd --must-not-run ssh
 
 RSBACKUP_VOLUME=rsb-volume \
-    RSBACKUP_VOLUME_path=/path/to/volume \
+    RSBACKUP_VOLUME_PATH=/path/to/volume \
     RSBACKUP_SSH_TARGET=localhost \
     RSBACKUP_HOOK=post-volume-hook \
     RSBACKUP_ACT=true \
     fake_run --must-output-empty \
     ./rsbackup-snapshot-hook -s ${fake_work}/snaps
+
+fake_check

--- a/tools/t-hook-post
+++ b/tools/t-hook-post
@@ -30,9 +30,13 @@ fake_cmd --must-run df "echo /dev/mapper/vg-lv" \
 fake_cmd --must-run umount \
          --must-args ${fake_work}/snaps/rsb-volume
 fake_cmd --must-run lvremove \
-         --must-args --force /dev/mapper/vg-lv.snap
-fake_cmd --must-run udevadm "echo /dev/dm-0 /dev/mapper/vg-lv" \
-         --must-args info -rqsymlink -n /dev/mapper/vg-lv
+         --must-args --force /dev/vg/lv.snap
+fake_cmd --must-run _dmsetup_info "echo vg-lv" \
+         --must-args info --noheadings -c -o name /dev/mapper/vg-lv
+fake_cmd --must-run _dmsetup_splitname "echo \"vg lv \"" \
+         --must-args splitname --noheadings --separator ' ' vg-lv LVM
+# Hack to mock two dmsetup verbs 'dmsetup info' / 'dmsetup splitname':
+fake_cmd dmsetup '_dmsetup_$1 "$@"'
 
 fake_cmd --must-not-run lvcreate
 fake_cmd --must-not-run fsck


### PR DESCRIPTION
This properly resolves issue #72 (`udevadm info -rqsymlink` not returning any output for some LVs, breaking `rsbackup-snapshot-hook`) for me. (Issue is already closed, but nothing was actually done about it.)

It works by replacing the invocation of `udevadm` (which was added to resolve #23) with `dmsetup`, which should hopefully be more robust.

As part of the rework:
- I moved to using `dmsetup splitname` to pull apart /dev/mapper device names, instead of shell ad-hockery. This should cope better with VG names containing hyphens.
- The device name used for snapshot LVs is now /dev/vg/lv.snap rather than /dev/mapper/vg-lv.snap. This oughtn't to make any difference to anything.

I have:
- updated and run the test suite;
- run it for real on Debian stable (backported to rsbackup 6.0), on one (1) volume so far (but I plan to continue to use it for my real backups);
- done an ad-hoc regression test for #23;
- checked a bit that I'm not adding excessively modern dependencies (`dmsetup splitname` dates back to at least 2009).

I have not:
- tested it on anything other than Debian stable amd64;
- tested it with a wide variety of LVM setups (e.g., RAID);
- tested it works remotely over ssh;
- actually tested on a live VG name containing hyphens.

Thanks to @ijackson and @cjwatson for assistance.

(The first commit does not change any functionality, but fixes a longstanding failure of the shell test suite used for rsbackup-snapshot-hook to run all its checks.)