### PR TITLE
debian: Don't install *.in.html in doc/

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -70,6 +70,7 @@ binary-rsbackup: build
 	gzip -9nv debian/rsbackup/usr/share/doc/rsbackup/*
 	cp doc/*.html doc/*.css debian/rsbackup/usr/share/doc/rsbackup/.
 	rm -f debian/rsbackup/usr/share/doc/rsbackup/*.prefix.html
+	rm -f debian/rsbackup/usr/share/doc/rsbackup/*.in.html
 	cp debian/copyright debian/rsbackup/usr/share/doc/rsbackup/.
 	$(INSTALL) -m 755 src/rsbackup debian/rsbackup/usr/bin/rsbackup
 	$(MAKE) -C tools install DESTDIR=$(shell pwd)/debian/rsbackup


### PR DESCRIPTION
`/usr/share/doc/rsbackup/` was ending up with both `rsbackup-manual.html` and `rsbackup-manual.in.html`, which was untidy.

I've tested with `dpkg-buildpackage` run in the git tree, and using `dpkg-deb -x` to spot check the resulting `.deb`.