### PR TITLE
doc/Makefile.am - correct permissions of rsbackup-manual.html

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -28,7 +28,7 @@ html: $(MANHTML) CHANGES.html README.html
 rsbackup-manual.html: rsbackup-manual.in.html Makefile
 	rm -f $@.new
 	sed 's/_version_/${VERSION}/g' < ${srcdir}/rsbackup-manual.in.html > $@.new
-	chmod 444 $@.new
+	chmod 644 $@.new
 	mv -f $@.new $@
 
 %.html: %


### PR DESCRIPTION
This was flagged by lintian; doc files should be 0644 (like every other one is), not 0444.