### PR TITLE
Warn when a `Volume::available` fails instead of terminating

### DIFF
--- a/src/Host.cc
+++ b/src/Host.cc
@@ -64,7 +64,7 @@ bool Host::available() const {
   if(hostCheck.at(0) == "always-up")
     return true;
   if(hostCheck.at(0) == "ssh")
-    return invoke(nullptr, "true", (const char *)nullptr) == 0;
+    return invoke(nullptr, nullptr, "true", (const char *)nullptr) == 0;
   if(hostCheck.at(0) == "command") {
     std::vector<std::string> args(hostCheck.begin() + 1, hostCheck.end());
     args.push_back(hostname);
@@ -119,7 +119,7 @@ void Host::write(std::ostream &os, int step, bool verbose) const {
   }
 }
 
-int Host::invoke(std::string *capture, const char *cmd, ...) const {
+int Host::invoke(std::string *stdout, std::string *stderr, const char *cmd, ...) const {
   std::vector<std::string> args;
   const char *arg;
   va_list ap;
@@ -139,14 +139,17 @@ int Host::invoke(std::string *capture, const char *cmd, ...) const {
     args.push_back(arg);
   va_end(ap);
   Subprocess sp(args);
-  if(capture) {
-    sp.capture(1, capture);
-    return sp.runAndWait(Subprocess::THROW_ON_CRASH);
+  if(stdout) {
+    sp.capture(1, stdout);
   } else {
     sp.nullChildFD(1);
-    sp.nullChildFD(2);
-    return sp.runAndWait(Subprocess::THROW_ON_CRASH);
   }
+  if(stderr) {
+    sp.capture(2, stderr);
+  } else {
+    sp.nullChildFD(2);
+  }
+  return sp.runAndWait(Subprocess::THROW_ON_CRASH);
 }
 
 ConfBase *Host::getParent() const {

--- a/src/Host.cc
+++ b/src/Host.cc
@@ -141,8 +141,7 @@ int Host::invoke(std::string *capture, const char *cmd, ...) const {
   Subprocess sp(args);
   if(capture) {
     sp.capture(1, capture);
-    return sp.runAndWait(Subprocess::THROW_ON_ERROR
-                         | Subprocess::THROW_ON_CRASH);
+    return sp.runAndWait(Subprocess::THROW_ON_CRASH);
   } else {
     sp.nullChildFD(1);
     sp.nullChildFD(2);

--- a/src/Host.h
+++ b/src/Host.h
@@ -111,12 +111,13 @@ public:
   static bool valid(const std::string &n);
 
   /** @brief Invoke a command on the host and return its exit status
-   * @param capture Where to put capture stdout, or null pointer
+   * @param stdout Where to capture stdout, or null pointer
+   * @param stderr Where to capture stderr, or null pointer
    * @param cmd Command to invoke
    * @param ... Arguments to command, terminatd by a null pointer
    * @return Exit status
    */
-  int invoke(std::string *capture, const char *cmd, ...) const;
+  int invoke(std::string *stdout, std::string *stderr, const char *cmd, ...) const;
 
   ConfBase *getParent() const override;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,7 +35,7 @@ RetireDevices.cc RetireVolumes.cc Store.cc stylesheet.cc	\
 Subprocess.cc Text.cc Unicode.cc Volume.cc Command.h Conf.h Date.h	\
 Defaults.h DeviceAccess.h Document.h Email.h Errors.h FileLock.h IO.h	\
 rsbackup.h Store.h Subprocess.h Utils.h ConfBase.cc		\
-toLines.cc trimNewline.cc globFiles.cc Database.h Database.cc Report.h			\
+toLines.cc trimNewline.cc globFiles.cc Database.h Database.cc Report.h	\
 parseInteger.cc split.cc EventLoop.cc EventLoop.h nonblock.cc		\
 Action.cc Action.h BulkRemove.h Selection.h Selection.cc Color.h 	\
 Color.cc parseFloat.cc Render.h Render.cc HistoryGraph.h	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,7 +35,7 @@ RetireDevices.cc RetireVolumes.cc Store.cc stylesheet.cc	\
 Subprocess.cc Text.cc Unicode.cc Volume.cc Command.h Conf.h Date.h	\
 Defaults.h DeviceAccess.h Document.h Email.h Errors.h FileLock.h IO.h	\
 rsbackup.h Store.h Subprocess.h Utils.h ConfBase.cc		\
-toLines.cc globFiles.cc Database.h Database.cc Report.h			\
+toLines.cc trimNewline.cc globFiles.cc Database.h Database.cc Report.h			\
 parseInteger.cc split.cc EventLoop.cc EventLoop.h nonblock.cc		\
 Action.cc Action.h BulkRemove.h Selection.h Selection.cc Color.h 	\
 Color.cc parseFloat.cc Render.h Render.cc HistoryGraph.h	\

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -65,6 +65,11 @@ void progressBar(IO &stream, const char *prompt, size_t done, size_t total);
  */
 size_t toLines(std::vector<std::string> &lines, const std::string &s);
 
+/** @brief Remove newline from the end of a string
+  * @param s Input string
+ */
+void trimNewline(std::string *s);
+
 /** @brief Expand a filename glob pattern
  * @param files List of filenames
  * @param pattern Pattern

--- a/src/Volume.cc
+++ b/src/Volume.cc
@@ -142,7 +142,8 @@ bool Volume::available() const {
     // Guess which version of stat to use based on uname.
     if(parent->invoke(&os, &os_err, "uname", "-s", (const char *)nullptr) != 0) {
       trimNewline(&os_err);
-      warning(WARNING_ALWAYS, "'uname' failed on %s - %s", parent->hostname.c_str(), os_err.c_str());
+      warning(WARNING_ALWAYS, "'uname' failed on %s - %s",
+              parent->hostname.c_str(), os_err.c_str());
       return false;
     }
     if(os == "Darwin"
@@ -156,7 +157,8 @@ bool Volume::available() const {
     if(parent->invoke(&stats, &stats_err, "stat", option, "%d", path.c_str(),
                       parent_directory.c_str(), (const char *)nullptr) != 0) {
       trimNewline(&stats_err);
-      warning(WARNING_ALWAYS, "'stat' failed on %s - '%s'", parent->hostname.c_str(), stats_err.c_str());
+      warning(WARNING_ALWAYS, "'stat' failed on %s - %s",
+              parent->hostname.c_str(), stats_err.c_str());
       return false;
     }
     // Split output into lines

--- a/src/Volume.cc
+++ b/src/Volume.cc
@@ -136,12 +136,15 @@ const Backup *Volume::mostRecentFailedBackup(const Device *device) const {
 
 bool Volume::available() const {
   if(checkMounted) {
-    std::string os, stats;
+    std::string os, os_err, stats, stats_err;
     std::string parent_directory = path + "/..";
     const char *option;
     // Guess which version of stat to use based on uname.
-    if(parent->invoke(&os, "uname", "-s", (const char *)nullptr) != 0)
+    if(parent->invoke(&os, &os_err, "uname", "-s", (const char *)nullptr) != 0) {
+      trimNewline(&os_err);
+      warning(WARNING_ALWAYS, "'uname' failed on %s - %s", parent->hostname.c_str(), os_err.c_str());
       return false;
+    }
     if(os == "Darwin"
        || (os.size() >= 3 && os.compare(os.size() - 3, 3, "BSD") == 0)) {
       option = "-f";
@@ -150,9 +153,12 @@ bool Volume::available() const {
       option = "-c";
     }
     // Get the device numbers for path and its parent
-    if(parent->invoke(&stats, "stat", option, "%d", path.c_str(),
-                      parent_directory.c_str(), (const char *)nullptr))
+    if(parent->invoke(&stats, &stats_err, "stat", option, "%d", path.c_str(),
+                      parent_directory.c_str(), (const char *)nullptr) != 0) {
+      trimNewline(&stats_err);
+      warning(WARNING_ALWAYS, "'stat' failed on %s - '%s'", parent->hostname.c_str(), stats_err.c_str());
       return false;
+    }
     // Split output into lines
     std::vector<std::string> lines;
     toLines(lines, stats);
@@ -165,7 +171,7 @@ bool Volume::available() const {
   if(checkFile.size()) {
     std::string file =
         (checkFile[0] == '/' ? checkFile : path + "/" + checkFile);
-    if(parent->invoke(nullptr, "test", "-e", file.c_str(),
+    if(parent->invoke(nullptr, nullptr, "test", "-e", file.c_str(),
                       (const char *)nullptr)
        != 0)
       return false;

--- a/src/trimNewline.cc
+++ b/src/trimNewline.cc
@@ -1,0 +1,31 @@
+// Copyright © 2014, 2015 Richard Kettlewell.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#include <config.h>
+#include "Utils.h"
+
+void trimNewline(std::string *s) {
+  if (s->empty())
+  {
+      return;
+  }
+  if (s->back() == '\n') 
+  {
+      s->pop_back();
+  }
+  if (s->back() == '\r') 
+  {
+      s->pop_back();
+  }
+}


### PR DESCRIPTION
This is an attempt to fix #119

If I read the code correctly, all callers to `Host::invoke` check the returned `status` but do not catch an exception. With this PR no exception is raised, but a warning gets emitted when the status is not `0` and output is captured. When `Host::invoke` is called without capturing `stdout` no exception was raised already, which makes both cases consistent.

In consequence `/usr/bin/rsbackup --backup` now exits with `0` instead of `139` (SIGSEGV), when a `Volume::available` check fails due to network or host issues (after the `Host::available` was initially successful). I believe this is consistent with the other warnings returning `0`.

```text
WARNING: 'uname' failed on other.host.invalid - ssh: Could not resolve hostname other.host.invalid: Name or service not known
```

This may change behavior of [rsbackup.cron](https://github.com/ewxrjk/rsbackup/blob/master/tools/rsbackup.cron.in) as it now continues with the next host when there is an error instead of terminating. Since the result is mapped to `true` anyway, I think this is the correct way.

Please let me know if anything missing, or you would like to receive the PR in a different format.