### PR TITLE
Remove two unnecessary build-dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ case "$host" in
     PKG_CHECK_MODULES([SQLITE3],[sqlite3])
     ;;
 esac
-boost="-lboost_filesystem -lboost_system"
+boost="-lboost_filesystem"
 AC_SUBST([BOOST_LIBS],[${boost}])
 AC_CHECK_LIB([pthread],[pthread_create])
 AC_CHECK_LIB([iconv],[iconv_open])

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.6.0
 Section: admin
 Homepage: https://www.greenend.org.uk/rjk/rsbackup/
 Vcs-Git: https://github.com/ewxrjk/rsbackup
-Build-Depends: lynx|lynx-cur,devscripts,sqlite3,libsqlite3-dev,libboost-system-dev,libboost-filesystem-dev,libboost-dev,pkgconf,libpangomm-1.4-dev,libcairomm-1.0-dev,xattr,acl
+Build-Depends: lynx|lynx-cur,devscripts,sqlite3,libsqlite3-dev,libboost-filesystem-dev,libboost-dev,pkgconf,libpangomm-1.4-dev,libcairomm-1.0-dev,xattr,acl
 
 Package: rsbackup
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.6.0
 Section: admin
 Homepage: https://www.greenend.org.uk/rjk/rsbackup/
 Vcs-Git: https://github.com/ewxrjk/rsbackup
-Build-Depends: lynx|lynx-cur,devscripts,sqlite3,libsqlite3-dev,libboost-filesystem-dev,libboost-dev,pkgconf,libpangomm-1.4-dev,libcairomm-1.0-dev,xattr,acl
+Build-Depends: lynx|lynx-cur,sqlite3,libsqlite3-dev,libboost-filesystem-dev,libboost-dev,pkgconf,libpangomm-1.4-dev,libcairomm-1.0-dev,xattr,acl
 
 Package: rsbackup
 Architecture: any


### PR DESCRIPTION
The build doesn't need devscripts, so remove it.

Likewise, libboost-system-dev hasn't been necessary since boost 1.69, and needs to be removed for builds with boost 1.90 and later to work.

Both changes fix Debian bugs.